### PR TITLE
Add unique order prefix for each payment request

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -37,7 +37,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway {
 		$this->method_description 	= __( 'Allows payments by Komoju, dedicated to Japanese online and offline payment gateways.', 'woocommerce' );
 		$this->testmode       		= 'yes' === $this->get_option( 'testmode', 'yes' );
 		$this->debug          		= 'yes' === $this->get_option( 'debug', 'yes' );
-		$this->invoice_prefixe		= $this->get_option( 'invoice_prefix' );
+		$this->invoice_prefix		= $this->get_option( 'invoice_prefix' );
         $this->accountID     		= $this->get_option( 'accountID' );
         $this->secretKey     		= $this->get_option( 'secretKey' );
         $this->callbackURL     		= $this->get_option( 'callbackURL' );
@@ -55,7 +55,6 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway {
 		$this->title        = $this->get_option( 'title' );
 		$this->description  = $this->get_option( 'description' );
 		$this->instructions = $this->get_option( 'instructions', $this->description );
-		
 		$this->notify_url = $this->callbackURL == '' ? WC()->api_request_url( 'WC_Gateway_Komoju' ) : $this->callbackURL;
 		// Filters
 		// Actions
@@ -65,7 +64,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway {
 			WC_Gateway_Komoju::log( 'is not valid for use. No IPN set.' );
 		} else {
 			include_once( 'includes/class-wc-gateway-komoju-ipn-handler.php' );
-			new WC_Gateway_Komoju_IPN_Handler( $this->testmode, $this->notify_url, $this->secretKey, $this->invoice_prefixe );
+			new WC_Gateway_Komoju_IPN_Handler( $this->testmode, $this->notify_url, $this->secretKey, $this->invoice_prefix );
 		}
 
 	}

--- a/includes/class-wc-gateway-komoju-request.php
+++ b/includes/class-wc-gateway-komoju-request.php
@@ -33,6 +33,7 @@ class WC_Gateway_Komoju_Request {
 	public function __construct( $gateway ) {
 		$this->gateway    = $gateway;
 		$this->notify_url = $this->gateway->notify_url;
+ 		$this->request_id = substr(str_shuffle("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, 6);
 		$this->Komoju_endpoint = '/ja/api/'.$this->gateway->accountID. '/transactions/';
 	}
 
@@ -44,7 +45,7 @@ class WC_Gateway_Komoju_Request {
 	 */
 	public function get_request_url( $order, $sandbox = false, $method = 'credit_card' ) {
 		$komoju_args = $this->get_komoju_args( $order, $method );
-	
+
 		if ( $sandbox ) {
 			return 'https://sandbox.komoju.com' . $this->Komoju_endpoint.$method.'/new'.'?' .$komoju_args;
 		} else {
@@ -68,7 +69,7 @@ class WC_Gateway_Komoju_Request {
 				"transaction[customer][family_name]"		=> $order->billing_last_name,
 				"transaction[customer][given_name_kana]"	=> $order->billing_first_name,
 				"transaction[customer][family_name_kana]"	=> $order->billing_last_name,
-				"transaction[external_order_num]"			=> $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(),
+				"transaction[external_order_num]"			=> $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number() . '-' . $this->request_id,
 				"transaction[return_url]"					=> $this->gateway->get_return_url( $order ),
 				"transaction[cancel_url]"					=> $order->get_cancel_order_url_raw(),
 				"transaction[callback_url]"					=> $this->notify_url,
@@ -83,11 +84,11 @@ class WC_Gateway_Komoju_Request {
 		}
 		sort($qs_params);
 		$query_string = implode('&', $qs_params);
-		
+
 		$url = $this->Komoju_endpoint.$method.'/new'. '?' .$query_string;
 		$hmac = hash_hmac('sha256', $url, $this->gateway->secretKey);
 		$query_string .= '&hmac='.$hmac;
-		
+
 		return $query_string;
 	}
 

--- a/includes/class-wc-gateway-komoju-response.php
+++ b/includes/class-wc-gateway-komoju-response.php
@@ -23,7 +23,7 @@ abstract class WC_Gateway_Komoju_Response {
 			return false;
 		}
 
-		if ( ! $order = wc_get_order( substr( $order_id, strlen( $invoice_prefix ) ) ) ) {
+		if ( ! $order = wc_get_order( substr( $order_id, strlen( $invoice_prefix ), -7) ) ) {
 			WC_Gateway_Komoju::log( 'Error: Cannot locate order in WC with order_id: .'.$order_id.' minus prefix: '.$invoice_prefix );
 			return false;
 		}


### PR DESCRIPTION
When hitting the "Back" button in your browser and selecting a new payment
method Komoju will complain that the order ID is no longer unique preventing you
from creating a payment.

This pull request tacks on a random 6 letter string every time a payment request is made.
When the callback is processed the prefix and the suffix are stripped to get the order number.

![image](https://cloud.githubusercontent.com/assets/82835/16442040/2e4b449e-3e0a-11e6-9531-85793ad9b947.png)

Tested capturing the payment which works:

![image](https://cloud.githubusercontent.com/assets/82835/16442135/f25b3a2e-3e0a-11e6-8b76-8ddc79f829c3.png)

