### PR TITLE
Sanitise user input for payment method

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -120,7 +120,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway {
 		$order          = wc_get_order( $order_id );
 		$komoju_request = new WC_Gateway_Komoju_Request( $this );
 		$payment_method = sanitize_text_field($_POST['komoju-method']);
-		
+
 		return array(
 			'result'   => 'success',
 			'redirect' => $komoju_request->get_request_url( $order, $payment_method ) 

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -119,9 +119,11 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway {
 		include_once( 'includes/class-wc-gateway-komoju-request.php' );
 		$order          = wc_get_order( $order_id );
 		$komoju_request = new WC_Gateway_Komoju_Request( $this );
+		$payment_method = sanitize_text_field($_POST['komoju-method']);
+		
 		return array(
 			'result'   => 'success',
-			'redirect' => $komoju_request->get_request_url( $order, $_POST['komoju-method'] ) 
+			'redirect' => $komoju_request->get_request_url( $order, $payment_method ) 
 		);
 	}
 


### PR DESCRIPTION
After submitting the plugin to WordPress.org we were informed that we needed to implement sanitisation on the payment method field, before using it to construct the hosted page URL.