### PR TITLE
Fix: include discounts in amount being charged

### DIFF
--- a/includes/class-wc-gateway-komoju-request.php
+++ b/includes/class-wc-gateway-komoju-request.php
@@ -37,7 +37,7 @@ class WC_Gateway_Komoju_Request {
 	 */
 	public function get_request_url( $order, $method = 'credit_card' ) {
 		$komoju_args = $this->get_komoju_args( $order, $method );
-			
+
 		return 'https://komoju.com' . $this->Komoju_endpoint.$method.'/new'.'?' .$komoju_args;
 	}
 
@@ -52,7 +52,7 @@ class WC_Gateway_Komoju_Request {
 		WC_Gateway_Komoju::log( 'Generating payment form for order ' . $order->get_order_number() );
 
 		$params = array(
-				"transaction[amount]"                       => $this->get_order_total($order),
+				"transaction[amount]"                       => $order->get_total(),
 				"transaction[currency]"                     => get_woocommerce_currency(),
 				"transaction[customer][email]"              => $order->get_billing_email(),
 				"transaction[customer][phone]"              => $order->get_billing_phone(),
@@ -61,7 +61,7 @@ class WC_Gateway_Komoju_Request {
 				"transaction[external_order_num]"           => $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number() . '-' . $this->request_id,
 				"transaction[return_url]"                   => $this->gateway->get_return_url( $order ),
 				"transaction[cancel_url]"                   => $order->get_cancel_order_url_raw(),
-				"transaction[tax]"                          => $this->get_tax_total($order),
+				"transaction[tax]"                          => 0,
 				"timestamp"                                 => time(),
 				"via"                                       => "woocommerce"
 		);
@@ -130,35 +130,5 @@ class WC_Gateway_Komoju_Request {
 		}
 
 		return number_format( $price, $decimals, '.', '' );
-	}
-
-	/**
-	 * gets the order total. Because we send the tax as a separate value to
-	 * Komoju we need to remove it from the order total, otherwise it would
-	 * be added twice.
-	 * 
-	 * @param WC_Order $order
-	 * 
-	 * @return int
-	 */
-	protected function get_order_total ( $order ) {
-		$orderTotal = $order->get_total();
-		$taxTotal = $this->get_tax_total($order);
-
-		return $orderTotal - $taxTotal;
-	}
-
-	/**
-	 * gets the total tax applied to the order. If there is no tax then it
-	 * returns a 0 to ensure the result is always a number.
-	 * 
-	 * @param WC_Order $order
-	 * 
-	 * @return int
-	 */
-	protected function get_tax_total ( $order ) {
-		$hasTax = strlen($order->get_total_tax()) == 0;
-
-		return $hasTax ? 0 : $order->get_total_tax();
 	}
 }


### PR DESCRIPTION
## Context
Coupon discounts are not being correctly applied. When a coupon discount is added to the order, it correctly discounts the cost on the WooCommerce site, but once the user is directed to the Hosted Payments page, the full undiscounted price is being displayed (and charged):

WooCommerce checkout screen
<img width="736" alt="Screen Shot 2020-08-21 at 4 12 22 pm" src="https://user-images.githubusercontent.com/12392541/90864970-033ba080-e3d5-11ea-9cb1-b3d917a69b1d.png">

KOMOJU Hosted Page checkout screen (for konbini)
<img width="416" alt="Screen Shot 2020-08-21 at 4 12 50 pm" src="https://user-images.githubusercontent.com/12392541/90864979-06cf2780-e3d5-11ea-9b99-cc752f697d26.png">


### Why?

When calculating the order amount we combine together several different order price fields (order subtotal & total shipping cost). The problem with this is that the order subtotal is the base price of the item without additional tax or discount amounts applied. So when we create the payment we aren't applying the discount.

The [`order->getTotal()`](https://woocommerce.github.io/code-reference/classes/WC-Abstract-Order.html#method_get_total) method exists for this specific purpose, as it's a single value that encapsulates everything. However, it also includes tax, so we can't use it (because the Hosted Page API requires tax to be sent as a different value).

### The Solution

Since we want the order total without the tax amount, I've updated the code to just subtract tax from the order total. This feels simpler and should be more robust.

## How To Test
- set up as per the[dev notes](https://github.com/komoju/komoju-woocommerce/blob/master/docs/dev_setup.md), with one exception, make sure to set up shipping, give it a flat rate (500 Yen for example)
- go to woocommerce settings
- on the general tab, scroll down until you see the "enable taxes" and "enable coupons"
- Click "Enable tax rates and calculations" and "Enable the use of coupon codes":
<img width="1226" alt="Screen Shot 2020-08-21 at 5 11 17 pm" src="https://user-images.githubusercontent.com/12392541/90865146-4dbd1d00-e3d5-11ea-8dd3-47c16ef76bf7.png">

- Go to the bottom of the tab and click "Save Changes"
- on the Settings page, go to the tax tab
- put in the settings as per the picture:
<img width="680" alt="Screen Shot 2020-08-21 at 5 14 08 pm" src="https://user-images.githubusercontent.com/12392541/90865186-5a417580-e3d5-11ea-8039-4380528231d2.png">

- click on the "Standard Rates" link, just below the tabs
- click on "insert row"
- Leave all location fields as *, and enter a "Rate" and "Tax Name":
<img width="1266" alt="Screen Shot 2020-08-21 at 5 15 40 pm" src="https://user-images.githubusercontent.com/12392541/90865241-6a595500-e3d5-11ea-8aa8-b421834ba077.png">

- Save Changes
- On the WooCommerce section on the left sidebar, click Coupons
- Click "Add Coupon"
- Fill out the coupon code and coupon data:
<img width="1139" alt="Screen Shot 2020-08-21 at 5 12 02 pm" src="https://user-images.githubusercontent.com/12392541/90865260-7513ea00-e3d5-11ea-8af0-aaa875f06fad.png">

- Click "Publish" on the right side.

then go to the store, checkout with an item and check that the order total on the WooCommerce matches the order total + tax displayed on the hosted page.

You should then see the price on the WooCommerce checkout page match the order total + tax on the KOMOJU Payment page:
<img width="698" alt="Screen Shot 2020-08-21 at 5 22 09 pm" src="https://user-images.githubusercontent.com/12392541/90865398-a7254c00-e3d5-11ea-8b80-8707f1674b4a.png">
<img width="405" alt="Screen Shot 2020-08-21 at 5 22 22 pm" src="https://user-images.githubusercontent.com/12392541/90865405-aa203c80-e3d5-11ea-884a-f77645db50ef.png">

