### PR TITLE
Fix docs deployment failure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,14 +26,11 @@ jobs:
       - name: Build docs
         run: mkdocs build
 
-      - name: Deploy to gh-pages using PAT
-        run: |
-          cd site
-          git init
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote add origin "https://${{ secrets.DOCS_DEPLOY_TOKEN }}@github.com/degica/komoju-woocommerce.git"
-          git checkout -b gh-pages
-          git add .
-          git commit -m "Deploy docs"
-          git push origin gh-pages --force
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          cname: tech.degica.com/komoju-woocommerce
+          full_commit_message: "Deploy docs from CI"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,29 +8,38 @@ on:
       - 'mkdocs.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
         uses: actions/checkout@v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-
       - name: Install dependencies
         run: pip install mkdocs mkdocs-material mkdocs-static-i18n
-
       - name: Build docs
         run: mkdocs build
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          personal_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
-          publish_dir: ./site
-          publish_branch: gh-pages
-          cname: tech.degica.com/komoju-woocommerce
-          full_commit_message: "Deploy docs from CI"
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,13 +31,17 @@ jobs:
         run: pip install mkdocs mkdocs-material mkdocs-static-i18n
       - name: Build docs
         run: mkdocs build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site  # MkDocs output folder
 
   deploy:
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Komoju-WooCommerce Plugin Docs
 site_url: "https://tech.degica.com/komoju-woocommerce/"
-repo_url: https://github.com/degica/komoju-woocommerce
-repo_name: "degica/komoju-woocommerce"
+repo_url: https://github.com/komoju/komoju-woocommerce
+repo_name: "komoju/komoju-woocommerce"
 
 theme:
   name: material


### PR DESCRIPTION
# Description 

This updates the documentation deployment workflow. Our docs deployment was failing with PAT. So, remove PAT and followed the official github guide to deploy docs.

- Replaces manual git commands with a cleaner, secure deployment step
- Deploys content from the ./site directory to the gh-pages branch