### PR TITLE
[CPF-264] Block Line pay forcefully

### DIFF
--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -304,7 +304,7 @@ class WC_Settings_Page_Komoju extends WC_Settings_Page
             return;
         }
 
-        // CPF-264 Force emove linepay settings
+        // CPF-264 Force remove linepay settings
         delete_option('woocommerce_komoju_linepay_settings');
 
         // Clear gateway settings from removed entries

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -304,6 +304,9 @@ class WC_Settings_Page_Komoju extends WC_Settings_Page
             return;
         }
 
+        // CPF-264 Force emove linepay settings
+        delete_option('woocommerce_komoju_linepay_settings');
+
         // Clear gateway settings from removed entries
         if ($old_payment_types) {
             $to_remove = array_diff($old_payment_types, $payment_types);
@@ -370,6 +373,11 @@ class WC_Settings_Page_Komoju extends WC_Settings_Page
             foreach ($all_payment_methods as $payment_method) {
                 $slug        = $payment_method['type_slug'];
                 $pm_currency = $payment_method['currency'];
+
+                // CPF-264 Remove linepay from the list of payment methods
+                if ($slug === 'linepay') {
+                    continue;
+                }
 
                 // If $slug is not set, register
                 if (!isset($methods_by_slug[$slug])) {

--- a/index.php
+++ b/index.php
@@ -41,6 +41,10 @@ function woocommerce_komoju_init()
         $komoju_payment_methods = get_option('komoju_woocommerce_payment_methods');
         if (gettype($komoju_payment_methods) == 'array') {
             foreach ($komoju_payment_methods as $payment_method) {
+                // CPF-264 Remove linepay from the list of payment methods
+                if (isset($payment_method['type_slug']) && $payment_method['type_slug'] === 'linepay') {
+                    continue;
+                }
                 $methods[] = new WC_Gateway_Komoju_Single_Slug($payment_method);
             }
         }

--- a/tests/cypress/e2e/admin.cy.js
+++ b/tests/cypress/e2e/admin.cy.js
@@ -26,6 +26,20 @@ describe('KOMOJU for WooCommerce: Admin', () => {
     cy.contains('Komoju - PayPay');
   })
 
+  it('LINE pay should not exist', () => {
+    cy.setupKomoju(['konbini', 'credit_card']);
+    cy.clickPaymentTab();
+
+    cy.contains('Komoju - Konbini');
+    cy.contains('Komoju - Credit Card');
+
+    cy.setupKomoju(['paypay', 'linepay']);
+    cy.clickPaymentTab();
+
+    cy.contains('Komoju - PayPay')
+    cy.contains('Komoju - LINE Pay').should('not.exist');
+  });
+
   it('lets me change the KOMOJU endpoint', () => {
     cy.visit('/wp-admin/admin.php?page=wc-settings&tab=komoju_settings&section=api_settings');
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -128,9 +128,19 @@ Cypress.Commands.add('setupKomoju', (
     });
   });
 
-  for (const slug of paymentTypes) {
-    cy.get(`input[type="checkbox"][value="${slug}"]`).click();
-  }
+  paymentTypes.forEach(slug => {
+    cy.get('body').then($body => {
+      if ($body.find(`input[type="checkbox"][value="${slug}"]`).length) {
+        cy.get(`input[type="checkbox"][value="${slug}"]`)
+          .click()
+          .then(() => {
+            cy.log(`Komoju payment method checkbox for "${slug}" found and clicked.`);
+          });
+      } else {
+        cy.log(`Komoju payment method checkbox for "${slug}" not found.`);
+      }
+    });
+  });
 
   cy.contains('Save changes').click();
 });


### PR DESCRIPTION
# Description

This PR removes support for the LINE Pay payment method from the KOMOJU WooCommerce plugin, ensuring it is completely blocked from being registered, cached, or loaded as a payment gateway.

All the code added with `CPF-264` comment above, so we can find and remove these lines easily.