### PR TITLE
[CORE-600] Update usage of deprecated set-output syntax

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -127,7 +127,7 @@ if $INPUT_GENERATE_ZIP; then
   echo "Generating zip file..."
   cd "$SVN_DIR/trunk" || exit
   zip -r "${PWD}/${SLUG}.zip" .
-  echo "::set-output name=zip-path::${PWD}/${SLUG}.zip"
+  echo "zip-path=${PWD}/${SLUG}.zip" >> $GITHUB_OUTPUT
   cp "${PWD}/${SLUG}.zip" $GIT_DIR
   echo "✓ Zip file generated!"
 fi


### PR DESCRIPTION
GitHub has deprecated the usage of `set-output` syntax and advised user to pipe the output to `$GITHUB_OUTPUT` file instead: https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/

Note that the removal of this usage has been postponed for quite a few times, but we don't know when GitHub will pull this. So, it's best to just fix this.