### PR TITLE
CPF-318 Add line_items property when creating session

### DIFF
--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -137,12 +137,21 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
             $order_total = $this->get_order_total();
         }
 
+        $amount = self::to_cents($order_total, $currency);
+
         $session_params = [
-            'amount'         => self::to_cents($order_total, $currency),
+            'amount'         => $amount,
             'currency'       => $currency,
             'default_locale' => self::get_locale_or_fallback(),
             'metadata'       => [
                 'woocommerce_note' => 'This session is only for rendering inline fields, and will not be completed.',
+            ],
+            'line_items'     => [
+                [
+                    'amount'      => $amount,
+                    'description' => 'Purchase',
+                    'quantity'    => 1,
+                ]
             ],
         ];
 

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -151,7 +151,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
                     'amount'      => $amount,
                     'description' => 'Purchase',
                     'quantity'    => 1,
-                ]
+                ],
             ],
         ];
 


### PR DESCRIPTION
## ✅ Purpose

This PR fixes a `missing_parameter` error thrown when creating a session in **WooCommerce** for merchants who have **Atone** enabled.  
The Komoju API requires the `line_items` parameter, which was previously missing in the session creation request.

---

## 🛠️ Changes Made

- Added the `line_items` property to the `$session_params` array inside the `create_session_for_fields` method.
- `line_items` now includes:
  - `amount`: same as the session `amount` in cents.
  - `description`: hardcoded as `Purchase`.
  - `quantity`: set to `1`.
